### PR TITLE
Remove [] as default parameter of EData

### DIFF
--- a/chyp/graph.py
+++ b/chyp/graph.py
@@ -25,12 +25,12 @@ class VData:
         self.out_edges = out_edges
 
 class EData:
-    def __init__(self, s: List[int]=[], t: List[int]=[], x: float=0, y: float=0, value: Any="", hyper: bool=True):
+    def __init__(self, s: List[int]=None, t: List[int]=None, x: float=0, y: float=0, value: Any="", hyper: bool=True):
         self.value = value
         self.x = x
         self.y = y
-        self.s = s
-        self.t = t
+        self.s = [] if s is None else s
+        self.t = [] if t is None else t
         self.hyper = hyper
 
 class Graph:


### PR DESCRIPTION
Empty list [] in default parameters can cause problems. 
Consider the following snippet:

```
edata1 = EData()
edata2 = EData()

# This will change both objects 
edata1.s.append(1)

print("edata 1", edata1.s).  # <- [1]
print("edata 2", edata2.s) #  <- [1] bad
```

To avoid this just use None as default param and set it to [] if necessary inside __init__.