### PR TITLE
Implement support for monoidal unit in typed diagrams

### DIFF
--- a/chyp/state.py
+++ b/chyp/state.py
@@ -122,7 +122,8 @@ class State(lark.Transformer):
         if (len(items) == 1
            and isinstance(items[0], int)):
             return items[0]
-        return [str(item) for item in items]
+        return [str(item) for item in items
+                if item != 'None']
 
     def id(self, _: List[Any]) -> Graph:
         return identity()


### PR DESCRIPTION
A special keyword, None, can be used to denote the monoidal unit when specifying vertex types.

When None appears in a monoidal product, it is simply ignored e.g.
`gen f : A * None -> None * B * None * None * C`
is the same as writing
`gen f : A -> B * C`